### PR TITLE
maintenance : deprecation symfony

### DIFF
--- a/DependencyInjection/EkoFeedExtension.php
+++ b/DependencyInjection/EkoFeedExtension.php
@@ -31,7 +31,7 @@ class EkoFeedExtension extends Extension
      * @param array            $configs   An array of configuration settings
      * @param ContainerBuilder $container A container builder instance
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 
@@ -55,7 +55,7 @@ class EkoFeedExtension extends Extension
      *
      * @throws \RuntimeException
      */
-    protected function configureHydrator(array $config, ContainerBuilder $container)
+    protected function configureHydrator(array $config, ContainerBuilder $container): void
     {
         if (!$container->hasDefinition($config['hydrator'])) {
             throw new \RuntimeException(sprintf('Unable to load hydrator service "%s"', $config['hydrator']));


### PR DESCRIPTION
Return void type for method in EkoFeedExtension.

Resolve the `might add "void" as a native return type declaration in the future`

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      |no
| New feature?  |no
| BC breaks?    | yes/no
| Deprecations? | yes
| Tests pass?   | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any
